### PR TITLE
Update to UPF summary responsiblity

### DIFF
--- a/draft-mishra-scone-usecase.md
+++ b/draft-mishra-scone-usecase.md
@@ -377,7 +377,7 @@ flow to/from a UE to the UPF.
     - The gNB forwards the packets to the UE over the air-interface.  UE-side modem stack then transparently passes the application packets to the app hosted on the UE.
 
 In summary, the UPF is responsible for packet routing and forwarding, packet
-inspection and filtering, subscriber policy enforcement, inline services (NAT, firewall, DNS etc) and QoS handling.
+inspection and filtering, participating in subscriber and flow policy enforcement, inline services (NAT, firewall, DNS etc) and QoS handling.
 
 # Security Considerations
 


### PR DESCRIPTION
UPF is not solely responsible for subscriber policy enforcement, hence, it only participate enforcing some parts, while RAN also has responsiblity to enforce the policies.