### PR TITLE
Added more details on 5G

### DIFF
--- a/draft-mishra-scone-usecase.md
+++ b/draft-mishra-scone-usecase.md
@@ -418,6 +418,16 @@ attributes to SCONE flows so that the advised throughput is not degraded
 under high-load conditions. They can also dynamically update SCONE rate 
 advice in response to network load variations.
 
+The UPF can be configured to enforce a Maximum Bitrate (MBR) of traffic 
+calculated across over an averaging window (default 2seconds). The 
+enforcement may be applied on different granularities, all traffic 
+carried within a PDU session with default QoS, all traffic mapped to 
+a specific QoS flow within a PDU session, or just the traffic of a 
+specific application traffic flow mapped to a specific QoS flow. The 
+restriction can be separated for upstream and downstream directions. By 
+default, the throughput advice reflects the MBR value the UPF is 
+configured for a particular SCONE-capable traffic flow. 
+
 ### Dynamic Updates
 When prefered mobile networks can enforce dynamic rate limits during active sessions, 
 for example on a QoS Flow basis. In such cases, a SCONE Network element in 5G network 


### PR DESCRIPTION
MBR is currently the value in 5G specification that the UPF can use, it is important to show what the 5G network already can do.